### PR TITLE
make compatible with ILI lib, plus minor fixeups.

### DIFF
--- a/examples/graphicstest/graphicstest.ino
+++ b/examples/graphicstest/graphicstest.ino
@@ -18,6 +18,8 @@
 #include "Adafruit_GFX.h"
 #include "WROVER_KIT_LCD.h"
 
+#define min(X, Y) (((X) < (Y)) ? (X) : (Y))
+
 WROVER_KIT_LCD tft;
 
 void setup() {

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
-name=Adafruit ILI9341
+name=WROVER KIT LCD
 version=1.0.3
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
-sentence=Library for Adafruit ILI9341 displays
-paragraph=Library for Adafruit ILI9341 displays
+sentence=Library for WROVER displays
+paragraph=Library for WROVER displays
 category=Display
 url=https://github.com/adafruit/WROVER_KIT_LCD
 architectures=*

--- a/src/WROVER_KIT_LCD.cpp
+++ b/src/WROVER_KIT_LCD.cpp
@@ -369,7 +369,6 @@ void WROVER_KIT_LCD::fillRect(int16_t x, int16_t y, int16_t w, int16_t h,
 }
 
 // This code was ported/adapted from https://github.com/PaulStoffregen/ILI9341_t3
-// by Marc MERLIN. See examples/pictureEmbed to use this.
 void WROVER_KIT_LCD::drawBitmap(int16_t x, int16_t y, int16_t w, int16_t h, const uint16_t *pcolors) {
     startWrite();
     setAddrWindow(x, y, w, h);

--- a/src/WROVER_KIT_LCD.cpp
+++ b/src/WROVER_KIT_LCD.cpp
@@ -229,7 +229,7 @@ void WROVER_KIT_LCD::invertDisplay(boolean i) {
 
 void WROVER_KIT_LCD::scrollTo(uint16_t y) {
     startWrite();
-    writeCommand(0x37);
+    writeCommand(WROVER_VSCRSADD);
     SPI.write16(y);
     endWrite();
 }
@@ -365,6 +365,15 @@ void WROVER_KIT_LCD::fillRect(int16_t x, int16_t y, int16_t w, int16_t h,
         uint16_t color) {
     startWrite();
     writeFillRect(x,y,w,h,color);
+    endWrite();
+}
+
+// This code was ported/adapted from https://github.com/PaulStoffregen/ILI9341_t3
+// by Marc MERLIN. See examples/pictureEmbed to use this.
+void WROVER_KIT_LCD::drawBitmap(int16_t x, int16_t y, int16_t w, int16_t h, const uint16_t *pcolors) {
+    startWrite();
+    setAddrWindow(x, y, w, h);
+    writePixels((uint16_t*) pcolors, w*h);
     endWrite();
 }
 

--- a/src/WROVER_KIT_LCD.h
+++ b/src/WROVER_KIT_LCD.h
@@ -98,6 +98,41 @@
 #define WROVER_GREENYELLOW 0xAFE5 /* 173, 255,  47 */
 #define WROVER_PINK        0xF81F
 
+
+// Compatibility with ILI code.
+#define ILI9341_WIDTH       WROVER_WIDTH       
+#define ILI9341_HEIGHT      WROVER_HEIGHT      
+
+#define ILI9341_RDMODE      WROVER_RDDPM       
+#define ILI9341_RDMADCTL    WROVER_RDDMADCTL   
+#define ILI9341_RDPIXFMT    WROVER_RDDCOLMOD   
+#define ILI9341_RDIMGFMT    WROVER_RDDIM       
+#define ILI9341_RDSELFDIAG  WROVER_RDDSDR      
+
+#define ILI9341_BLACK       WROVER_BLACK       
+#define ILI9341_NAVY        WROVER_NAVY        
+#define ILI9341_DARKGREEN   WROVER_DARKGREEN   
+#define ILI9341_DARKCYAN    WROVER_DARKCYAN    
+#define ILI9341_MAROON      WROVER_MAROON      
+#define ILI9341_PURPLE      WROVER_PURPLE      
+#define ILI9341_OLIVE       WROVER_OLIVE       
+#define ILI9341_LIGHTGREY   WROVER_LIGHTGREY   
+#define ILI9341_DARKGREY    WROVER_DARKGREY    
+#define ILI9341_BLUE        WROVER_BLUE        
+#define ILI9341_GREEN       WROVER_GREEN       
+#define ILI9341_CYAN        WROVER_CYAN        
+#define ILI9341_RED         WROVER_RED         
+#define ILI9341_MAGENTA     WROVER_MAGENTA     
+#define ILI9341_YELLOW      WROVER_YELLOW      
+#define ILI9341_WHITE       WROVER_WHITE       
+#define ILI9341_ORANGE      WROVER_ORANGE      
+#define ILI9341_GREENYELLOW WROVER_GREENYELLOW 
+#define ILI9341_PINK        WROVER_PINK        
+
+// These get redefined to an incompatible 3 arg version in arduino libs.
+#define min(X, Y) (((X) < (Y)) ? (X) : (Y))
+#define max(X, Y) (((X) > (Y)) ? (X) : (Y))
+
 typedef enum {
     JPEG_DIV_NONE,
     JPEG_DIV_2,
@@ -141,6 +176,7 @@ class WROVER_KIT_LCD : public Adafruit_GFX {
         void      drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color);
         void      drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
         void      fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color);
+        void      drawBitmap(int16_t x, int16_t y, int16_t w, int16_t h, const uint16_t *pcolors);
 
         uint8_t   readcommand8(uint8_t reg, uint8_t index = 0);
         uint32_t  readId();

--- a/src/WROVER_KIT_LCD.h
+++ b/src/WROVER_KIT_LCD.h
@@ -129,10 +129,6 @@
 #define ILI9341_GREENYELLOW WROVER_GREENYELLOW 
 #define ILI9341_PINK        WROVER_PINK        
 
-// These get redefined to an incompatible 3 arg version in arduino libs.
-#define min(X, Y) (((X) < (Y)) ? (X) : (Y))
-#define max(X, Y) (((X) > (Y)) ? (X) : (Y))
-
 typedef enum {
     JPEG_DIV_NONE,
     JPEG_DIV_2,


### PR DESCRIPTION
- fix library.properties
- minor cleanup on scrollTo (ported back from ILI lib)
- ported drawBitmap back from ILI lib.
- Added ILI defines in .h so that WROVER can be dropped in place
  for code that used to use the ILI library.
- Added min/max to override the bad versions that come from arduino libs
  (even the examples/graphicstest will not compile without those).