### PR TITLE
RAMRD (0x2E) implementation

### DIFF
--- a/src/WROVER_KIT_LCD.cpp
+++ b/src/WROVER_KIT_LCD.cpp
@@ -115,24 +115,9 @@ uint32_t WROVER_KIT_LCD::readId() {
 }
 
 
-
-uint16_t WROVER_KIT_LCD::pullColor() {
-    startWrite();
-    uint16_t color = readPixel();
-    endWrite();
-    return color;
-}
-
-uint16_t WROVER_KIT_LCD::readPixel() {
-    uint16_t buf[1];
-    readPixels(buf, 1);
-    return buf[0];
-}
-
 uint16_t WROVER_KIT_LCD::readPixels(uint16_t *colors, uint32_t len) {
     uint8_t f;
     uint16_t ret = len;
-
     writeCommand(0xD9);
     SPI.write(0x10);
     writeCommand(WROVER_RAMRD);
@@ -144,7 +129,6 @@ uint16_t WROVER_KIT_LCD::readPixels(uint16_t *colors, uint32_t len) {
       uint8_t b = SPI.transfer(0);
       *colors++ = color565(r, g, b);
     }
-
     return ret;
 }
 
@@ -156,7 +140,8 @@ uint16_t WROVER_KIT_LCD::readPixel(int16_t x, int16_t y) {
     return buf[0];
 }
 
-uint16_t WROVER_KIT_LCD::readPixels(int16_t x, int16_t y, uint16_t w, uint16_t h, uint16_t *block) {
+
+uint16_t WROVER_KIT_LCD::readPixels(int16_t x, int16_t y, uint16_t w, uint16_t h, uint16_t *colors) {
     uint8_t f;
     uint16_t len = w*h;
     uint16_t ret = len;
@@ -167,7 +152,7 @@ uint16_t WROVER_KIT_LCD::readPixels(int16_t x, int16_t y, uint16_t w, uint16_t h
     }
     startWrite(); // begin transaction
     setAddrWindow(x, y, w, h);
-    readPixels(block, len);
+    readPixels(colors, len);
     endWrite(); // end transaction
     _freq = freq;
     return len;

--- a/src/WROVER_KIT_LCD.cpp
+++ b/src/WROVER_KIT_LCD.cpp
@@ -115,11 +115,9 @@ uint32_t WROVER_KIT_LCD::readId() {
 }
 
 
-uint16_t WROVER_KIT_LCD::readPixels(uint16_t *colors, uint32_t len) {
+uint32_t WROVER_KIT_LCD::readPixels(uint16_t *colors, uint32_t len) {
     uint8_t f;
-    uint16_t ret = len;
-    writeCommand(0xD9);
-    SPI.write(0x10);
+    uint32_t ret = len;
     writeCommand(WROVER_RAMRD);
     f = SPI.transfer(0); // dummy read
     f = SPI.transfer(0); // dummy read
@@ -137,6 +135,19 @@ uint16_t WROVER_KIT_LCD::readPixel(int16_t x, int16_t y) {
     uint16_t buf[1];
     setAddrWindow(x, y, 1, 1);
     readPixels(buf, 1);
+    return buf[0];
+}
+
+uint16_t WROVER_KIT_LCD::readPixel() {
+    uint32_t freq = _freq;
+    if(_freq > 16000000){
+        _freq = 16000000;
+    }
+    uint16_t buf[1];
+    startWrite(); // begin transaction
+    readPixels(buf, 1);
+    endWrite(); // end transaction
+    _freq = freq;
     return buf[0];
 }
 

--- a/src/WROVER_KIT_LCD.h
+++ b/src/WROVER_KIT_LCD.h
@@ -158,11 +158,13 @@ class WROVER_KIT_LCD : public Adafruit_GFX {
 
         // Transaction API
         void      startWrite(void);
-        void      endWrite(void);
         void      writePixel(int16_t x, int16_t y, uint16_t color);
         void      writeFillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color);
         void      writeFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color);
         void      writeFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
+        uint16_t  readPixels(uint16_t *colors, uint32_t len);// Transaction API not used by GFX
+        uint16_t  readPixel(int16_t x, int16_t y);// Transaction API
+        void      endWrite(void);
 
         // Transaction API not used by GFX
         void      setAddrWindow(uint16_t x, uint16_t y, uint16_t w, uint16_t h);
@@ -176,16 +178,10 @@ class WROVER_KIT_LCD : public Adafruit_GFX {
         void      drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
         void      fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color);
         void      drawBitmap(int16_t x, int16_t y, int16_t w, int16_t h, const uint16_t *pcolors);
+        uint16_t  readPixels(int16_t x, int16_t y, uint16_t w, uint16_t h, uint16_t *colors);
 
         uint8_t   readcommand8(uint8_t reg, uint8_t index = 0);
         uint32_t  readId();
-        
-        uint16_t  pullColor();
-        uint16_t  readPixel();
-        uint16_t  readPixel(int16_t x, int16_t y);
-        uint16_t  readPixels(uint16_t *colors, uint32_t len);
-        uint16_t  readPixels(int16_t x, int16_t y, uint16_t w, uint16_t h, uint16_t *block);
-
 
         uint16_t  color565(uint8_t r, uint8_t g, uint8_t b);
         void      startBitmap(uint16_t x, uint16_t y, uint16_t w, uint16_t h);

--- a/src/WROVER_KIT_LCD.h
+++ b/src/WROVER_KIT_LCD.h
@@ -162,7 +162,7 @@ class WROVER_KIT_LCD : public Adafruit_GFX {
         void      writeFillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color);
         void      writeFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color);
         void      writeFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
-        uint16_t  readPixels(uint16_t *colors, uint32_t len);// Transaction API not used by GFX
+        uint32_t  readPixels(uint16_t *colors, uint32_t len);// Transaction API not used by GFX
         uint16_t  readPixel(int16_t x, int16_t y);// Transaction API
         void      endWrite(void);
 
@@ -179,6 +179,7 @@ class WROVER_KIT_LCD : public Adafruit_GFX {
         void      fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color);
         void      drawBitmap(int16_t x, int16_t y, int16_t w, int16_t h, const uint16_t *pcolors);
         uint16_t  readPixels(int16_t x, int16_t y, uint16_t w, uint16_t h, uint16_t *colors);
+        uint16_t  readPixel(); // read color of the pixel at last cursor position
 
         uint8_t   readcommand8(uint8_t reg, uint8_t index = 0);
         uint32_t  readId();

--- a/src/WROVER_KIT_LCD.h
+++ b/src/WROVER_KIT_LCD.h
@@ -179,6 +179,8 @@ class WROVER_KIT_LCD : public Adafruit_GFX {
 
         uint8_t   readcommand8(uint8_t reg, uint8_t index = 0);
         uint32_t  readId();
+        uint16_t  readPixel(int16_t x, int16_t y);
+        uint16_t  readPixels(int16_t x, int16_t y, uint16_t w, uint16_t h, uint16_t *block);
 
         uint16_t  color565(uint8_t r, uint8_t g, uint8_t b);
         void      startBitmap(uint16_t x, uint16_t y, uint16_t w, uint16_t h);

--- a/src/WROVER_KIT_LCD.h
+++ b/src/WROVER_KIT_LCD.h
@@ -179,8 +179,13 @@ class WROVER_KIT_LCD : public Adafruit_GFX {
 
         uint8_t   readcommand8(uint8_t reg, uint8_t index = 0);
         uint32_t  readId();
+        
+        uint16_t  pullColor();
+        uint16_t  readPixel();
         uint16_t  readPixel(int16_t x, int16_t y);
+        uint16_t  readPixels(uint16_t *colors, uint32_t len);
         uint16_t  readPixels(int16_t x, int16_t y, uint16_t w, uint16_t h, uint16_t *block);
+
 
         uint16_t  color565(uint8_t r, uint8_t g, uint8_t b);
         void      startBitmap(uint16_t x, uint16_t y, uint16_t w, uint16_t h);


### PR DESCRIPTION

Adding `readPixel(x, y)` and `readPixels(x, y, w, h, buffer)` so screenshots become possible.

/!\ It seems to only work at 16MHz otherwise palette corruption occurs

